### PR TITLE
feat: add differential evolution option

### DIFF
--- a/examples/4_example_experiment_setups/4f_robot_brain_cmaes_database/config.py
+++ b/examples/4_example_experiment_setups/4f_robot_brain_cmaes_database/config.py
@@ -2,9 +2,39 @@
 
 from revolve2.standards.modular_robots_v2 import gecko_v2
 
+# Database and run configuration
 DATABASE_FILE = "database.sqlite"
-NUM_REPETITIONS = 5
-NUM_SIMULATORS = 8
-INITIAL_STD = 0.5
-NUM_GENERATIONS = 100
+NUM_REPETITIONS = 2
+NUM_SIMULATORS = 4
+NUM_GENERATIONS = 200
 BODY = gecko_v2()
+
+# CMA-ES configuration
+INITIAL_STD = 0.5
+
+# Optimization algorithm selection: "cmaes" or "de"
+OPTIMIZER = "cmaes"
+
+# Differential Evolution configuration
+POPULATION_SIZE = 100
+DE_F = 0.8
+DE_CR = 0.9
+
+# Simulation parameters
+SIMULATION_SECONDS = 30
+
+# Generation transition for weighting
+TRANSITION_LENGTH = 10  # generations for weight transition
+
+# Fitness weights
+W_HEIGHT = 1.0
+W_MOVE_MAX = 1.5
+W_YAW = 0.3
+FALL_PENALTY = 1.0
+
+# Thresholds
+FALL_HEIGHT_THRESHOLD = 0.06  # m
+H_MIN, H_MAX = 0.06, 0.25
+
+# Parameter bounds for controllers
+BOUNDS = (-1.0, 1.0)

--- a/examples/4_example_experiment_setups/4f_robot_brain_cmaes_database/evaluator.py
+++ b/examples/4_example_experiment_setups/4f_robot_brain_cmaes_database/evaluator.py
@@ -1,13 +1,19 @@
-"""Evaluator class."""
+"""Evaluator – three-phase fitness with yaw penalty."""
+
+from __future__ import annotations
 
 import math
+from typing import Iterable
 
 import numpy as np
 import numpy.typing as npt
 
 from revolve2.modular_robot import ModularRobot
 from revolve2.modular_robot.body.base import ActiveHinge, Body
-from revolve2.modular_robot.brain.cpg import BrainCpgNetworkStatic, CpgNetworkStructure
+from revolve2.modular_robot.brain.cpg import (
+    BrainCpgNetworkStatic,
+    CpgNetworkStructure,
+)
 from revolve2.modular_robot_simulation import (
     ModularRobotScene,
     Terrain,
@@ -17,9 +23,34 @@ from revolve2.simulators.mujoco_simulator import LocalSimulator
 from revolve2.standards import fitness_functions, terrains
 from revolve2.standards.simulation_parameters import make_standard_batch_parameters
 
+import config
+
+
+def _quat_xyzw(q) -> tuple[float, float, float, float]:
+    """Extract (x, y, z, w) from a quaternion-like object."""
+    if hasattr(q, "x") and hasattr(q, "w"):
+        return float(q.x), float(q.y), float(q.z), float(q.w)
+    if hasattr(q, "xyzw"):
+        x, y, z, w = q.xyzw
+        return float(x), float(y), float(z), float(w)
+    if hasattr(q, "elements"):
+        e = q.elements
+        return float(e[0]), float(e[1]), float(e[2]), float(e[3])
+    arr = np.array(q, dtype=float).ravel()
+    if arr.size != 4:
+        raise ValueError("Quaternion-like with size {arr.size}, expected 4")
+    return float(arr[0]), float(arr[1]), float(arr[2]), float(arr[3])
+
+
+def _yaw_from_quat_xyzw(x: float, y: float, z: float, w: float) -> float:
+    """Return yaw (rotation around Z) from quaternion in (x,y,z,w)."""
+    t0 = 2.0 * (w * z + x * y)
+    t1 = 1.0 - 2.0 * (y * y + z * z)
+    return math.atan2(t0, t1)
+
 
 class Evaluator:
-    """Provides evaluation of robots."""
+    """Evaluate controllers on a fixed body."""
 
     _simulator: LocalSimulator
     _terrain: Terrain
@@ -35,70 +66,97 @@ class Evaluator:
         body: Body,
         output_mapping: list[tuple[int, ActiveHinge]],
     ) -> None:
-        """
-        Initialize this object.
-
-        :param headless: `headless` parameter for the physics simulator.
-        :param num_simulators: `num_simulators` parameter for the physics simulator.
-        :param cpg_network_structure: Cpg structure for the brain.
-        :param body: Modular body of the robot.
-        :param output_mapping: A mapping between active hinges and the index of their corresponding cpg in the cpg network structure.
-        """
-        self._simulator = LocalSimulator(
-            headless=headless, num_simulators=num_simulators
-        )
+        self._simulator = LocalSimulator(headless=headless, num_simulators=num_simulators)
         self._terrain = terrains.flat()
         self._cpg_network_structure = cpg_network_structure
         self._body = body
         self._output_mapping = output_mapping
+        self.current_generation: int = 0
+
+    def _make_robots(self, params_list: Iterable[npt.NDArray[np.float_]]) -> list[ModularRobot]:
+        robots: list[ModularRobot] = []
+        for params in params_list:
+            brain = BrainCpgNetworkStatic.uniform_from_params(
+                params=params,
+                cpg_network_structure=self._cpg_network_structure,
+                initial_state_uniform=math.sqrt(2) * 0.5,
+                output_mapping=self._output_mapping,
+            )
+            robots.append(ModularRobot(body=self._body, brain=brain))
+        return robots
 
     def evaluate(
         self,
         solutions: list[npt.NDArray[np.float_]],
+        generation: int | None = None,
     ) -> npt.NDArray[np.float_]:
-        """
-        Evaluate multiple robots.
+        """Evaluate multiple controller parameter sets."""
+        g = generation if generation is not None else self.current_generation
 
-        Fitness is the distance traveled on the xy plane.
+        robots = self._make_robots(solutions)
 
-        :param solutions: Solutions to evaluate.
-        :returns: Fitnesses of the solutions.
-        """
-        # Create robots from the brain parameters.
-        robots = [
-            ModularRobot(
-                body=self._body,
-                brain=BrainCpgNetworkStatic.uniform_from_params(
-                    params=params,
-                    cpg_network_structure=self._cpg_network_structure,
-                    initial_state_uniform=math.sqrt(2) * 0.5,
-                    output_mapping=self._output_mapping,
-                ),
-            )
-            for params in solutions
-        ]
-
-        # Create the scenes.
         scenes = []
         for robot in robots:
             scene = ModularRobotScene(terrain=self._terrain)
             scene.add_robot(robot)
             scenes.append(scene)
 
-        # Simulate all scenes.
         scene_states = simulate_scenes(
             simulator=self._simulator,
-            batch_parameters=make_standard_batch_parameters(),
+            batch_parameters=make_standard_batch_parameters(
+                simulation_time=config.SIMULATION_SECONDS
+            ),
             scenes=scenes,
         )
 
-        # Calculate the xy displacements.
-        xy_displacements = [
-            fitness_functions.xy_displacement(
-                states[0].get_modular_robot_simulation_state(robot),
-                states[-1].get_modular_robot_simulation_state(robot),
-            )
-            for robot, states in zip(robots, scene_states)
-        ]
+        # Phase-based weight switching
+        gA_end = config.NUM_GENERATIONS // 3
+        trans = config.TRANSITION_LENGTH
+        if g < gA_end:
+            w_move = 0.0
+            w_yaw = 0.0
+        elif g < gA_end + trans:
+            alpha = (g - gA_end) / trans
+            w_move = alpha * config.W_MOVE_MAX
+            w_yaw = alpha * config.W_YAW
+        else:
+            w_move = config.W_MOVE_MAX
+            w_yaw = config.W_YAW
 
-        return np.array(xy_displacements)
+        fits: list[float] = []
+        for robot, states in zip(robots, scene_states):
+            ms0 = states[0].get_modular_robot_simulation_state(robot)
+            msN = states[-1].get_modular_robot_simulation_state(robot)
+
+            pose0 = ms0.get_pose()
+            pose1 = msN.get_pose()
+
+            dxy = fitness_functions.xy_displacement(ms0, msN)
+
+            x0, y0, z0, w0 = _quat_xyzw(pose0.orientation)
+            x1, y1, z1, w1 = _quat_xyzw(pose1.orientation)
+            yaw0 = _yaw_from_quat_xyzw(x0, y0, z0, w0)
+            yawN = _yaw_from_quat_xyzw(x1, y1, z1, w1)
+            dyaw = abs(yawN - yaw0)
+
+            start = int(len(states) * 0.4)
+            z_seq = [
+                s.get_modular_robot_simulation_state(robot).get_pose().position[2]
+                for s in states[start:]
+            ]
+            h_bar = float(np.mean(z_seq))
+            fell = any(z < config.FALL_HEIGHT_THRESHOLD for z in z_seq)
+
+            h_clamp = np.clip(
+                h_bar - config.H_MIN, 0.0, config.H_MAX - config.H_MIN
+            ) / (config.H_MAX - config.H_MIN)
+
+            fit = (
+                config.W_HEIGHT * h_clamp
+                + w_move * dxy
+                - w_yaw * dyaw
+                - (config.FALL_PENALTY if fell else 0.0)
+            )
+            fits.append(float(fit))
+
+        return np.array(fits)

--- a/examples/4_example_experiment_setups/4f_robot_brain_cmaes_database/main.py
+++ b/examples/4_example_experiment_setups/4f_robot_brain_cmaes_database/main.py
@@ -4,6 +4,7 @@ import logging
 
 import cma
 import config
+import numpy as np
 from database_components import (
     Base,
     Experiment,
@@ -35,7 +36,7 @@ def run_experiment(dbengine: Engine) -> None:
     logging.info("Start experiment")
 
     # Create an rng seed.
-    rng_seed = seed_from_time() % 2**32  # Cma seed must be smaller than 2**32.
+    rng_seed = seed_from_time() % 2**32  # compatible with cma.
 
     # Create and save the experiment instance.
     experiment = Experiment(rng_seed=rng_seed)
@@ -47,14 +48,11 @@ def run_experiment(dbengine: Engine) -> None:
     # Find all active hinges in the body
     active_hinges = config.BODY.find_modules_of_type(ActiveHinge)
 
-    # Create a structure for the CPG network from these hinges.
-    # This also returns a mapping between active hinges and the index of there corresponding cpg in the network.
-    (
-        cpg_network_structure,
-        output_mapping,
-    ) = active_hinges_to_cpg_network_structure_neighbor(active_hinges)
+    # Create a structure for the CPG network and mapping.
+    cpg_network_structure, output_mapping = active_hinges_to_cpg_network_structure_neighbor(
+        active_hinges
+    )
 
-    # Intialize the evaluator that will be used to evaluate robots.
     evaluator = Evaluator(
         headless=True,
         num_simulators=config.NUM_SIMULATORS,
@@ -63,48 +61,107 @@ def run_experiment(dbengine: Engine) -> None:
         output_mapping=output_mapping,
     )
 
-    # Initial parameter values for the brain.
-    initial_mean = cpg_network_structure.num_connections * [0.5]
+    if config.OPTIMIZER == "cmaes":
+        initial_mean = cpg_network_structure.num_connections * [0.5]
+        options = cma.CMAOptions()
+        options.set("bounds", list(config.BOUNDS))
+        options.set("seed", rng_seed)
+        opt = cma.CMAEvolutionStrategy(initial_mean, config.INITIAL_STD, options)
 
-    # Initialize the cma optimizer.
-    options = cma.CMAOptions()
-    options.set("bounds", [-1.0, 1.0])
-    options.set("seed", rng_seed)
-    opt = cma.CMAEvolutionStrategy(initial_mean, config.INITIAL_STD, options)
+        logging.info("Start optimization process (CMA-ES).")
+        while opt.countiter < config.NUM_GENERATIONS:
+            logging.info(
+                f"Generation {opt.countiter + 1} / {config.NUM_GENERATIONS}."
+            )
+            solutions = opt.ask()
+            fitnesses = evaluator.evaluate(solutions, generation=opt.countiter)
+            opt.tell(solutions, -fitnesses)
 
-    # Run cma for the defined number of generations.
-    logging.info("Start optimization process.")
-    while opt.countiter < config.NUM_GENERATIONS:
-        logging.info(f"Generation {opt.countiter + 1} / {config.NUM_GENERATIONS}.")
+            population = Population(
+                individuals=[
+                    Individual(genotype=Genotype(parameters), fitness=fitness)
+                    for parameters, fitness in zip(solutions, fitnesses)
+                ]
+            )
 
-        # Get the sampled solutions(parameters) from cma.
-        solutions = opt.ask()
+            generation = Generation(
+                experiment=experiment,
+                generation_index=opt.countiter,
+                population=population,
+            )
+            logging.info("Saving generation.")
+            with Session(dbengine, expire_on_commit=False) as session:
+                session.add(generation)
+                session.commit()
 
-        # Evaluate them.
-        fitnesses = evaluator.evaluate(solutions)
+    elif config.OPTIMIZER == "de":
+        rng = np.random.default_rng(rng_seed)
+        dim = cpg_network_structure.num_connections
+        bounds_low, bounds_high = config.BOUNDS
+        population = rng.uniform(bounds_low, bounds_high, size=(config.POPULATION_SIZE, dim))
+        fitnesses = evaluator.evaluate(list(population), generation=0)
 
-        # Tell cma the fitnesses.
-        # Provide them negated, as cma minimizes but we want to maximize.
-        opt.tell(solutions, -fitnesses)
-
-        # From the samples and fitnesses, create a population that we can save.
-        population = Population(
+        pop = Population(
             individuals=[
-                Individual(genotype=Genotype(parameters), fitness=fitness)
-                for parameters, fitness in zip(solutions, fitnesses)
+                Individual(genotype=Genotype(params), fitness=fit)
+                for params, fit in zip(population, fitnesses)
             ]
         )
-
-        # Make it all into a generation and save it to the database.
         generation = Generation(
             experiment=experiment,
-            generation_index=opt.countiter,
-            population=population,
+            generation_index=0,
+            population=pop,
         )
         logging.info("Saving generation.")
         with Session(dbengine, expire_on_commit=False) as session:
             session.add(generation)
             session.commit()
+
+        gen = 0
+        while gen < config.NUM_GENERATIONS - 1:
+            logging.info(f"Generation {gen + 1} / {config.NUM_GENERATIONS}.")
+
+            trial_vectors = []
+            for i in range(config.POPULATION_SIZE):
+                indices = list(range(config.POPULATION_SIZE))
+                indices.remove(i)
+                r1, r2, r3 = rng.choice(indices, 3, replace=False)
+                mutant = population[r1] + config.DE_F * (population[r2] - population[r3])
+                mutant = np.clip(mutant, bounds_low, bounds_high)
+
+                cross = rng.random(dim) < config.DE_CR
+                if not np.any(cross):
+                    cross[rng.integers(dim)] = True
+                trial = np.where(cross, mutant, population[i])
+                trial_vectors.append(trial)
+
+            trial_fitnesses = evaluator.evaluate(trial_vectors, generation=gen + 1)
+
+            for i in range(config.POPULATION_SIZE):
+                if trial_fitnesses[i] > fitnesses[i]:
+                    population[i] = trial_vectors[i]
+                    fitnesses[i] = trial_fitnesses[i]
+
+            gen += 1
+
+            pop = Population(
+                individuals=[
+                    Individual(genotype=Genotype(params), fitness=fit)
+                    for params, fit in zip(population, fitnesses)
+                ]
+            )
+            generation = Generation(
+                experiment=experiment,
+                generation_index=gen,
+                population=pop,
+            )
+            logging.info("Saving generation.")
+            with Session(dbengine, expire_on_commit=False) as session:
+                session.add(generation)
+                session.commit()
+
+    else:
+        raise ValueError(f"Unknown optimizer '{config.OPTIMIZER}'")
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- extend CMA-ES brain example with switchable optimizer supporting differential evolution
- port custom phase-weighted evaluator with yaw penalty and fall handling
- expose training weights and DE parameters via config

## Testing
- `python -m py_compile examples/4_example_experiment_setups/4f_robot_brain_cmaes_database/config.py examples/4_example_experiment_setups/4f_robot_brain_cmaes_database/evaluator.py examples/4_example_experiment_setups/4f_robot_brain_cmaes_database/main.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'revolve2')*

------
https://chatgpt.com/codex/tasks/task_e_687a4c0b2fbc832aa34751e8fae29178