### PR TITLE
Ensure rerun uses final generation settings

### DIFF
--- a/erectus_brain_v2(DE+CMA)/rerun.py
+++ b/erectus_brain_v2(DE+CMA)/rerun.py
@@ -58,8 +58,8 @@ def main() -> None:
         output_mapping=output_mapping,
     )
 
-    # Show the robot.
-    evaluator.evaluate([parameters])
+    # Show the robot at the final generation.
+    evaluator.evaluate([parameters], generation=config.NUM_GENERATIONS - 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- evaluate best individual using the last training generation

## Testing
- `PYTHONPATH="\$PWD/modular_robot:\$PWD/modular_robot_physical:\$PWD/modular_robot_simulation:\$PWD/simulation:\$PWD/experimentation:\$PWD/simulators/mujoco_simulator:\$PWD/standards" python 'erectus_brain_v2(DE+CMA)/rerun.py'` *(fails: database does not exist)*
- `PYTHONPATH="\$PWD/modular_robot:\$PWD/modular_robot_physical:\$PWD/modular_robot_simulation:\$PWD/simulation:\$PWD/experimentation:\$PWD/simulators/mujoco_simulator:\$PWD/standards" pytest tests/examples/test_1a_simulate_single_robot.py -vv -s` *(fails: could not initialize GLFW)*


------
https://chatgpt.com/codex/tasks/task_e_689d0bc92f2c832a902d6b095d9e7024