### PR TITLE
Add batch experiment runner

### DIFF
--- a/erectus_brain_v1/config.py
+++ b/erectus_brain_v1/config.py
@@ -8,7 +8,7 @@ DATABASE_FILE = "database_v2_100gen_DE_Speed=3_middle.sqlite"
 
 NUM_REPETITIONS = 1
 NUM_SIMULATORS = 8
-NUM_GENERATIONS = 300
+NUM_GENERATIONS = 100
 
 # BODY = gecko_v1()
 BODY = gecko_v2()

--- a/erectus_brain_v1/run_all.py
+++ b/erectus_brain_v1/run_all.py
@@ -1,0 +1,46 @@
+"""Run multiple training configurations for comparison."""
+
+import config
+import main
+from revolve2.standards.modular_robots_v1 import gecko_v1
+from revolve2.standards.modular_robots_v2 import gecko_v2
+
+# configurations
+bodies = [
+    ("v1", gecko_v1()),
+    ("v2", gecko_v2()),
+]
+w_move_max_values = [3.0, 4.0, 5.0]
+height_groups = [
+    ("low", 0.03, 0.03, 0.20),
+    ("high", 0.06, 0.06, 0.25),
+]
+optimizers = ["de", "cmaes"]
+
+def run_all() -> None:
+    """Run all combinations of bodies, speed weights, heights and optimizers."""
+
+    config.NUM_GENERATIONS = 100
+
+    for body_name, body in bodies:
+        for w_move_max in w_move_max_values:
+            for height_label, fall_threshold, h_min, h_max in height_groups:
+                for optimizer in optimizers:
+                    config.BODY = body
+                    config.W_MOVE_MAX = w_move_max
+                    config.FALL_HEIGHT_THRESHOLD = fall_threshold
+                    config.H_MIN = h_min
+                    config.H_MAX = h_max
+                    config.OPTIMIZER = optimizer
+                    config.DATABASE_FILE = (
+                        f"database_{body_name}_W{int(w_move_max)}_H{height_label}_{optimizer}.sqlite"
+                    )
+                    print(
+                        f"Running: body={body_name}, W_MOVE_MAX={w_move_max},"
+                        f" heights={height_label}, optimizer={optimizer}"
+                    )
+                    main.main()
+
+
+if __name__ == "__main__":
+    run_all()


### PR DESCRIPTION
## Summary
- add configurable run_all script to automate 24 training configurations
- set default NUM_GENERATIONS to 100

## Testing
- `python -m py_compile erectus_brain_v1/run_all.py`
- `python -m py_compile erectus_brain_v1/config.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'revolve2')*


------
https://chatgpt.com/codex/tasks/task_e_689d0908e074832a8dea239a29c7dbd2